### PR TITLE
Fixed assumed semantic error in tcplocal, added terminal preference.

### DIFF
--- a/Listeners/ListenerScript.py
+++ b/Listeners/ListenerScript.py
@@ -1,16 +1,32 @@
 import subprocess
 import os
+from shutil import which
+
+default_expected_terminal = 'gnome-terminal'
+bad_terminals = [
+    "eterm-color",
+    "dumb"
+]
+
+def check_for_term(term_env_var):
+    return term_env_var == None or bool(list(filter(lambda bad_term: bad_term == term_env_var, bad_terminals)))
 
 def open_command_prompt(command):
     if os.name == 'nt':
         looper = f':loop\n{command}\ngoto loop'
         subprocess.Popen(f'start cmd /k "{looper}"', shell=True)
     else:
+        preferred_terminal = os.environ.get("TERM")
+        using_terminal = default_expected_terminal if check_for_term(preferred_terminal) else preferred_terminal
         looper = f'while true; do {command}; done; exec bash'
-        subprocess.Popen(['gnome-terminal', '--', 'bash', '-c', looper])
-
+        
+        if which(using_terminal) == None:
+            print("No usable terminal found. \n"  )
+            return
+        else: 
+            subprocess.Popen([using_terminal, '--', 'bash', '-c', looper])
 tcp = "nc -lvnp 4444"
-tcplocal = "nc -lvnp 4444 -s 127.0.0.1"
+tcplocal = "nc -lvn 127.0.0.1 4444"
 
 open_command_prompt(tcp)
 open_command_prompt(tcplocal)


### PR DESCRIPTION
The command for listening on 127.0.0.1 seemed incorrect, as -l and -s flags on netcat are incompatible. Assuming you want to listen on 127.0.0.1, I fixed the script and added support for a preferred terminal that isn't gnome-terminal.